### PR TITLE
fix: RequestsJSONDecodeError on session start.

### DIFF
--- a/WebChatGPT/utils.py
+++ b/WebChatGPT/utils.py
@@ -12,7 +12,7 @@ __common_error_support_info = "Incase you have no idea on how to get the cookies
 
 headers = request_headers = {
     "Accept": "text/event-stream",
-    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Encoding": "gzip, deflate",
     "Accept-Language": "en-US",
     "Alt-Used": "chat.openai.com",
     "Authorization": f"Bearer %(value)s",

--- a/WebChatGPT/utils.py
+++ b/WebChatGPT/utils.py
@@ -17,7 +17,6 @@ headers = request_headers = {
     "Alt-Used": "chat.openai.com",
     "Authorization": f"Bearer %(value)s",
     "Connection": "keep-alive",
-    # "Content-Length": "904",
     "Content-Type": "application/json",
     "Host": "chat.openai.com",
     "Origin": "https://chat.openai.com",


### PR DESCRIPTION
#2 It was just a compression error from the OpenAI side. You were requesting a compressed version response. So, the response was a binary object. That's the reason for the RequestsJSONDecodeError in session requests every time. I don't know if you were getting this error or not, but many of your `WebChatGPT` users were getting this error. It is working from my side now.